### PR TITLE
Add support for KaTeX math formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,39 @@ hyvor = "<your_hyvor_website_id>"
 # To enable mapbox maps
 [extra.mapbox]
 access_token = "<your_access_token>"
+
+# To enable rendering of KaTeX math formulas
+katex.enabled = true
+katex.auto_render = true
+```
+
+### KaTeX math formula support
+
+This theme contains math formula support using [KaTeX](https://katex.org/),
+which can be enabled by setting `katex.enabled = true` in the `extra` section
++of `config.toml`:
+
+```toml
+[extra]
+katex.enabled = true
+katex.auto_render = true
+```
+
+After enabling this extension, the `katex` short code can be used in documents:
+* `{{ katex(body="\KaTeX") }}` to typeset a math formula inlined into a text,
+  similar to `$...$` in LaTeX
+* `{% katex(block=true) %}\KaTeX{% end %}` to typeset a block of math formulas,
+  similar to `$$...$$` in LaTeX
+
+#### Automatic rendering without short codes
+
+Optionally, `\\( \KaTeX \\)` / `$ \KaTeX $` inline and `\\[ \KaTeX \\]` / `$$ \KaTeX $$`
+block-style automatic rendering is also supported, if enabled in the config:
+
+```toml
+[extra]
+katex.enabled = true
+katex.auto_render = true
 ```
 
 ## Features

--- a/content/docs/extended-shortcodes/index.md
+++ b/content/docs/extended-shortcodes/index.md
@@ -799,6 +799,23 @@ A radar chart provides a way of displaying multivariate data in the form of a tw
 }
 {% end %}
 
+# KaTeX
+[KaTeX](https://katex.org/) is a math typesetting library based on TeX
+
+**Code**
+
+```
+{%/* katex(block=true) */%}
+\KaTeX
+{%/* end */%}
+```
+
+**Output**
+
+{% katex(block=true) %}
+\KaTeX
+{% end %}
+
 **Photo By:**
 - [ALEXANDRE DINAUT](https://unsplash.com/@alexdinaut?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText) on [Unsplash](https://unsplash.com/@alexdinaut?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText)
 - [Chandler Cruttenden](https://unsplash.com/@chanphoto?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText) on [Unsplash](https://unsplash.com/@chanphoto?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText)

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,6 +52,29 @@
     gtag("config", "{{ config.extra.analytics.google }}");
   </script>
   {% endif %}
+
+  {% if config.extra.katex.enabled %}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
+    integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+    integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"
+    crossorigin="anonymous"></script>
+
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/mathtex-script-type.min.js"
+    integrity="sha384-LJ2FmexL77rmGm6SIpxq7y+XA6bkLzGZEgCywzKOZG/ws4va9fUVu2neMjvc3zdv"
+    crossorigin="anonymous"></script>
+  {% if config.extra.katex.auto_render %}
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+    integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous" onload="renderMathInElement(document.body, {
+				delimiters: [
+					{left: '$$', right: '$$', display: true},
+					{left: '$', right: '$', display: false},
+					{left: '\\(', right: '\\)', display: false},
+					{left: '\\[', right: '\\]', display: true}
+				]
+			});"></script>
+  {% endif %}
+  {% endif %}
 </head>
 
 <body class="has-background-white">
@@ -121,7 +144,8 @@
   <section class="section">
     <div class="container">
       <nav class="pagination is-centered" role="navigation" aria-label="pagination">
-        <a class="pagination-previous" href='{{ paginator.previous }}' {% if not paginator.previous %}disabled{% endif %}>
+        <a class="pagination-previous" href='{{ paginator.previous }}' {% if not paginator.previous %}disabled{% endif
+          %}>
           <span class="icon">
             <i class="fas fa-angle-double-left"></i>
           </span>
@@ -137,8 +161,7 @@
           {% for pager in range(start=1, end=paginator.number_pagers+1) %}
           <li>
             <a class="pagination-link {% if paginator.current_index == pager %}is-current{% endif %}"
-              href='{{ paginator.base_url }}{{pager}}'
-              aria-label="Goto page {{pager}}">
+              href='{{ paginator.base_url }}{{pager}}' aria-label="Goto page {{pager}}">
               {{pager}}
             </a>
           </li>

--- a/templates/shortcodes/katex.html
+++ b/templates/shortcodes/katex.html
@@ -1,0 +1,1 @@
+<script type="math/tex{% if block %};mode=display{% endif %}">{{body}}</script>


### PR DESCRIPTION
Hi,
first of all thx for this cool template.

I, as @m4dh0rs3, would like to use katex formulas, so I prepared this small PR.
It's mostly a copy of https://www.getzola.org/themes/even/ with 3 changes:
* Bumped katex version to 0.12
* Changed config keys to `extra.katex.*` 
* Added support for `$ $` inline syntax

You can find some rendered formulas here: https://ktsk.xyz/posts/mu123-unit3/

Original request: https://github.com/RatanShreshtha/DeepThought/issues/7