### PR TITLE
KaTeX support for individual pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ access_token = "<your_access_token>"
 
 If you want to have a multilingual navbar on your blog, you must add your new code language in the [languages](https://www.getzola.org/documentation/content/multilingual/#configuration) array in the `config.toml` file.
 
-**NOTE**: Don't add you default language to this array
+**NOTE**: Don't add your default language to this array
 
 ```toml
 languages = [
@@ -202,14 +202,13 @@ es:
 
 ### KaTeX math formula support
 
-This theme contains math formula support using [KaTeX](https://katex.org/),
-which can be enabled by setting `katex.enabled = true` in the `extra` section
-+of `config.toml`:
+This theme supports displaying LaTeX-styled math formulas via [KaTeX](https://katex.org/).
+Support can be enabled by setting `katex.enabled = true` in the `extra` section
+of `config.toml` (all pages support) or page's headers (individual pages support):
 
 ```toml
 [extra]
 katex.enabled = true
-katex.auto_render = true
 ```
 
 After enabling this extension, the `katex` short code can be used in documents:
@@ -221,7 +220,7 @@ After enabling this extension, the `katex` short code can be used in documents:
 #### Automatic rendering without short codes
 
 Optionally, `\\( \KaTeX \\)` / `$ \KaTeX $` inline and `\\[ \KaTeX \\]` / `$$ \KaTeX $$`
-block-style automatic rendering is also supported, if enabled in the config:
+block-style automatic rendering is also supported, if enabled (see above):
 
 ```toml
 [extra]

--- a/templates/page.html
+++ b/templates/page.html
@@ -179,6 +179,29 @@
 </script>
 {% endif %}
 
+{% if page.extra.katex.enabled %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
+  integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+  integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"
+  crossorigin="anonymous"></script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/mathtex-script-type.min.js"
+  integrity="sha384-LJ2FmexL77rmGm6SIpxq7y+XA6bkLzGZEgCywzKOZG/ws4va9fUVu2neMjvc3zdv"
+  crossorigin="anonymous"></script>
+{% if page.extra.katex.auto_render %}
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+  integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous" onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '$', right: '$', display: false},
+        {left: '\\(', right: '\\)', display: false},
+        {left: '\\[', right: '\\]', display: true}
+      ]
+    });"></script>
+{% endif %}
+{% endif %}
+
 {% if page.extra.comments and config.extra.commenting.disqus %}
 <script>
   var disqus_config = function () {


### PR DESCRIPTION
Other pull request (https://github.com/RatanShreshtha/DeepThought/pull/12) introduced KaTeX global support. That's too big for my use case as not all pages have a formula. There isn't a need to download KaTeX script on each page.

This PR is a copy-paste of KaTeX support from `base.html` to `page.htnl` with change of flag reference. 