### PR TITLE
An attempt to fix docs to prevent "`item.code` not found in context"

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ Go into your sites directory and type `zola serve`. You should see your new site
 ### Theme Options
 ```toml
 navbar_items = [
-	{ url = "$BASE_URL/", name = "Home" },
-	{ url = "$BASE_URL/posts", name = "Posts" },
-	{ url = "$BASE_URL/docs", name = "Docs" },
-	{ url = "$BASE_URL/tags", name = "Tags" },
-	{ url = "$BASE_URL/categories", name = "Categories" },
+ { code = "en", nav_items = [
+  { url = "$BASE_URL/", name = "Home" },
+  { url = "$BASE_URL/posts", name = "Posts" },
+  { url = "$BASE_URL/docs", name = "Docs" },
+  { url = "$BASE_URL/tags", name = "Tags" },
+  { url = "$BASE_URL/categories", name = "Categories" },
+ ]},
 ]
 
 # Add links to favicon, you can use https://realfavicongenerator.net/ to generate favicon for your site


### PR DESCRIPTION
When following the README I got an error.

```
lazy.codes on  zola-deep-thought [$!+?]
❯ zola build
Building site...
-> Creating 1 pages (0 orphan), 1 sections, and processing 0 images
Failed to build the site
Error: Failed to render section '/home/ethan/Documents/git/eopb/lazy.codes/content/_index.md'
Reason: Failed to render 'index.html' (error happened in a parent template)
Reason: Variable `item.code` not found in context while rendering 'index.html'
```

When I add `code = "en"` to `navbar_items` that solves the issue.