### PR TITLE
Add support for Academicons (correctly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ stackoverflow = "<stackoverflow_userid>"
 twitter = "<twitter_username>"
 instagram = "<instagram_usernaem>"
 behance = "<behance_username>"
+google_scholar = "<googlescholar_userid>"
+orcid = "<orcid_userid>"
 
 
 # To add google analytics

--- a/config.toml
+++ b/config.toml
@@ -57,6 +57,8 @@ linkedin = "ratanshreshtha"
 stackoverflow = "3728911"
 email = "deepthought@gmail.com"
 twitter = "RatanShreshtha"
+#orcid = ""
+#google_scholar = ""
 
 [extra.analytics]
 google = "UA-176984489-2"

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/galleria/1.6.1/themes/folio/galleria.folio.min.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/mapbox-gl@2.1.1/dist/mapbox-gl.min.css" rel="stylesheet" />
   <link href="https://use.fontawesome.com/releases/v5.15.3/css/all.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
   <link href="https://cdn.jsdelivr.net/npm/bulma@0.9.2/css/bulma.min.css" rel="stylesheet" />
   <link href="{{ get_url(path='deep-thought.css') }}" rel="stylesheet" />
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,5 +1,22 @@
 {% macro social_links(social_config) %}
 <p>
+
+  {% if social_config.google_scholar %}
+  <a href="https://scholar.google.com/citations?user={{ social_config.google_scholar }}" target="_blank">
+    <span class="icon is-large" title="Google Scholar">
+			<i class="ai ai-google-scholar ai-lg"></i>
+    </span>
+  </a>
+  {% endif %}
+
+  {% if social_config.orcid %}
+  <a href="https://orcid.org/{{ social_config.orcid }}" target="_blank">
+    <span class="icon is-large" title="ORCiD">
+      <i class="fab fa-orcid fa-lg"></i>
+    </span>
+  </a>
+  {% endif %}
+
   {% if social_config.facebook %}
   <a href="https://facebook.com/{{ social_config.facebook }}" target="_blank">
     <span class="icon is-large" title="Facebook">


### PR DESCRIPTION
Trying this again, I borked the last PR.

I added support for using [Academicons](https://jpswalsh.github.io/academicons/) which are commonly used in academic circles. Additionally, I added two new optional slots for providing ORCiD and Google Scholar pages in config.toml. I don't think licensing is incompatible, but maybe worth a second look.

Cheers!