### PR TITLE
Fix relative path

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -181,7 +181,7 @@ webmanifest = "/icons/site.webmanifest"
 
 [extra.author]
 name = "DeepThought"
-avatar = "/images/avatar.png"
+avatar = "images/avatar.png"
 
 [extra.social]
 facebook = "RatanShreshtha"


### PR DESCRIPTION
When the site is hosted under a subdomain, this link will be broken. With the fix it will be the proper relative path relative to base-url. Maybe one should also fix the ones for the favicon, but I didn't check it.