### PR TITLE
add other languages support in elasticlunr search

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,28 @@ katex.enabled = true
 katex.auto_render = true
 ```
 
+
+### Elasticlunr search in other language
+
+Zola use [Elasticlunr.js](https://github.com/weixsong/elasticlunr.js) to add full-text search feature.
+To use languages other than en (English), you need to add some javascript files. See the Zola's issue [#1349](https://github.com/getzola/zola/issues/1349).
+By placing the `templates/base.html`on your project and using the `other_lang_search_js` block, you can load the requred additional javascript files in the right timing.
+
+e.g. `templates/base.html`
+
+```html
+{% extends "DeepThought/templates/base.html" %}
+{% block other_lang_search_js %}
+  <script src="{{ get_url(path='js/lunr.stemmer.support.js') }}"></script>
+  <script src="{{ get_url(path='js/tinyseg.js') }}"></script>
+  <script src="{{ get_url(path='js/lunr.' ~ lang ~ '.js') }}"></script>
+  <script src="{{ get_url(path='js/search.js') }}"></script>
+{% endblock %}
+```
+
+More detailed explanations are aound in [elasticlunr's documents](https://github.com/weixsong/elasticlunr.js#other-languages-example-in-browser).
+
+
 ## Roadmap
 
 See the [open issues](https://github.com/RatanShreshtha/DeepThought/issues) for a list of proposed features (and known issues).

--- a/templates/base.html
+++ b/templates/base.html
@@ -208,7 +208,6 @@
   {%- block other_lang_search_js -%}
   {%- endblock -%}
   {%- endif -%}
-  <script src="{{ get_url(path='search_index.en.js') }}"></script>
   <script src="{{ get_url(path='js/site.js') }}"></script>
 
   {% block custom_js %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -202,7 +202,12 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.xkcd@1.1.13/dist/chart.xkcd.min.js"></script>
   <script src='https://api.mapbox.com/mapbox-gl-js/v2.4.1/mapbox-gl.js'></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/galleria/1.6.1/themes/folio/galleria.folio.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.6/elasticlunr.min.js"></script>
+  <script src="{{ get_url(path='elasticlunr.min.js') }}"></script>
+  <script src="{{ get_url(path='search_index.' ~ lang ~ '.js') }}"></script>
+  {%- if lang != "en" -%}
+  {%- block other_lang_search_js -%}
+  {%- endblock -%}
+  {%- endif -%}
   <script src="{{ get_url(path='search_index.en.js') }}"></script>
   <script src="{{ get_url(path='js/site.js') }}"></script>
 


### PR DESCRIPTION
Thank you for your amazing theme of Zola! I like it so much. And thank you for taking the time to read this PR.

I had some troubles in using your theme with my primary language - Japanese. Zola's full-text search engine is dependent on [elasiclunr.js](https://github.com/weixsong/elasticlunr.js).  And if we use languages other than default one which is English, we need to add some javascript files in right place.

You already prepare a `custom_js` block in `base.html` But the additional javascript files have to be loaded before your `site.js`. if not,  results of search have no style.

Thank you so much again!
