### PR TITLE
add extension points for the theme users to add their own CSS and JS.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,8 @@
   <link href="https://use.fontawesome.com/releases/v5.15.4/css/all.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css" rel="stylesheet" />
   <link href="{{ get_url(path='deep-thought.css') }}" rel="stylesheet" />
+  {% block user_custom_stylesheet %}
+  {% endblock %}
 
   <title>
     {% block title %}
@@ -211,6 +213,9 @@
   <script src="{{ get_url(path='js/site.js') }}"></script>
 
   {% block custom_js %}
+  {% endblock %}
+
+  {% block user_custom_js %}
   {% endblock %}
 </body>
 


### PR DESCRIPTION
I would like to have extension points for Theme users to add their own CSS and JS.
 
There is a `custom_js` block in `base.html`, but this is already used by Theme itself as an extension to `page.html`, etc., so it doesn't seem to be intended as an extension for Theme users.

It would be nice if you could suggest a better naming for the Tera blocks.

(I am always so grateful for your wonderful work. I especially love the Mermaid and Chart Shortcodes. Thank you.)
