### PR TITLE
fix: allow to display tag/categ headers

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -106,6 +106,9 @@
     </div>
   </nav>
 
+  {% block header %}
+  {% endblock %}
+
   {% block content %}
   {% endblock %}
 


### PR DESCRIPTION
Headers of `single` templates of tags and categories are never displayed:
- https://github.com/RatanShreshtha/DeepThought/blob/main/templates/categories/single.html#L3-L20
- https://github.com/RatanShreshtha/DeepThought/blob/main/templates/tags/single.html#L3-L20

Here is a fix to allow to display them in the `base` template.

No regression was found.