### PR TITLE
Add footer block

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -172,6 +172,7 @@
   {% block comment %}
   {% endblock %}
 
+  {% block footer %}
   <footer class="footer py-4">
     <div class="content has-text-centered">
       <p>
@@ -201,6 +202,7 @@
       </p>
     </div>
   </footer>
+  {% endblock %}
 
   {% if config.extra.galleria.enabled %}
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" crossorigin="anonymous"></script>


### PR DESCRIPTION
Hi,

This PR reintroduces the footer block which got removed in 44c25559a039e7a5d73cb578ee0639a4680ca79d. The reasons was related to an issue with the 404 error page but as you can see on the screenshot below, the 404 page is rendered as expected:

![Screenshot 2022-06-22 at 11-27-23 DeepThought](https://user-images.githubusercontent.com/9932586/174994924-022734ed-3a24-44c5-b671-0fa154e7192a.png)

Thanks.