### PR TITLE
Added if/else to use full post content when there is no summary

### DIFF
--- a/templates/categories/single.html
+++ b/templates/categories/single.html
@@ -47,6 +47,7 @@
             </div>
           </div>
           <div class="content mt-2">
+            {% if page.summary %}
             {{ page.summary | safe }}
             <a href='{{ page.permalink }}'>
               Read More
@@ -54,6 +55,9 @@
                 <i class="fas fa-arrow-right fa-xs"></i>
               </span>
             </a>
+            {% else %}
+            {{ page.content | safe }}
+            {% endif %}
           </div>
           <div class="columns">
             <div class="column">

--- a/templates/section.html
+++ b/templates/section.html
@@ -39,6 +39,7 @@
             </div>
           </div>
           <div class="content mt-2">
+            {% if page.summary %}
             {{ page.summary | safe }}
             <a class="has-text-danger-dark has-text-weight-semibold" href='{{ page.permalink }}'>
               Read More
@@ -46,6 +47,9 @@
                 <i class="fas fa-arrow-right fa-xs"></i>
               </span>
             </a>
+            {% else %}
+            {{ page.content | safe }}
+            {% endif %}
           </div>
           <div class="columns">
             <div class="column">

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -47,6 +47,7 @@
             </div>
           </div>
           <div class="content mt-2">
+            {% if page.summary %}
             {{ page.summary | safe }}
             <a href='{{ page.permalink }}'>
               Read More
@@ -54,6 +55,9 @@
                 <i class="fas fa-arrow-right fa-xs"></i>
               </span>
             </a>
+            {% else %}
+            {{ page.content | safe }}
+            {% endif %}
           </div>
           <div class="columns">
             <div class="column">


### PR DESCRIPTION
Reasoning: for very short posts for which there is no need for a summary. A summary should be optional by default.

The "Read More" could be pulled outside of the if/else but imo clicking a link called "Read more" only to find there is no more feels weird and it's annoying to have to put "<!-- more -->" at the bottom of every post.

