### PR TITLE
Adding social option: Signal

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -212,6 +212,7 @@ soundcloud = "RatanShreshtha"
 googleplay = "RatanShreshtha"
 orcid = "RatanShreshtha"
 google_scholar = "RatanShreshtha"
+signal = "12025550128"
 
 [extra.analytics]
 google = "UA-176984489-2"

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -65,6 +65,14 @@
   </a>
   {% endif %}
 
+  {% if social_config.signal %}
+  <a class="has-text-signal" href="https://signal.me/#p/+{{ social_config.signal }}" target="_blank">
+    <span class="icon is-large" title="Signal">
+      <i class="fa-regular fa-comment"></i>
+    </span>
+  </a>
+  {% endif %}
+
   {# Certainly not the best implementation but Tera bombs if you try to access a nonexistent key #}
   {% if social_config.mastodon_username %}
     {% set mastodon_username = social_config.mastodon_username %}


### PR DESCRIPTION
[Signal ](https://www.signal.org/) is a popular secured messaging protocol. This PR adds socials support for Signal. I have tested with and without a value in `config.toml` and the icon does toggle. The URL is valid, though I note that the icon is not an official one for the brand, I had to make do with what was available on FontAwesome. The phone number in the config is randomly generated and should not be valid. Feel free to adjust this as you like.

Regards and thanks,