### PR TITLE
Fix the missing pagination in page

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -71,7 +71,7 @@
 {% endblock %}
 
 {% block pagination %}
-{% if page.earlier or page.later or page.lighter or page.heavier %}
+{% if page.earlier or page.later or page.lighter or page.heavier or page.higher or page.lower %}
 <section class="section">
   <div class="container">
     <div class="columns is-centered">
@@ -107,6 +107,23 @@
           <div class="level-item has-text-centered">
             <a class="button is-black is-outlined" href="{{ page.lighter.permalink }}">
               {{ page.lighter.title }}<span class="icon ml-2">
+                <i class="fas fa-arrow-circle-right"></i>
+              </span>
+            </a>
+          </div>
+          {% endif %} {% if page.higher %}
+          <div class="level-item has-text-centered">
+            <a class="button is-black is-outlined" href="{{ page.higher.permalink }}">
+              <span class="icon mr-2">
+                <i class="fas fa-arrow-circle-left"></i>
+              </span>
+              {{ page.higher.title }}
+            </a>
+          </div>
+          {% endif %} {% if page.lower %}
+          <div class="level-item has-text-centered">
+            <a class="button is-black is-outlined" href="{{ page.lower.permalink }}">
+              {{ page.lower.title }}<span class="icon ml-2">
                 <i class="fas fa-arrow-circle-right"></i>
               </span>
             </a>


### PR DESCRIPTION
zola makes a breaking change to unify all pages sorting variable names in templates to `lower`/`higher` since version [0.16.0](https://github.com/getzola/zola/blob/master/CHANGELOG.md#0160-2022-07-16)

Ref:
- https://github.com/getzola/zola/blob/4e81dfb86b29cfe6657baf0bf5b9f3507f5f13e1/components/content/src/page.rs#L67-L70